### PR TITLE
locations & conferences queries schema fault

### DIFF
--- a/server/schema/Conference.ts
+++ b/server/schema/Conference.ts
@@ -5,13 +5,14 @@ import { Contact, ContactType } from "./Contact";
 import { Location } from "./Location";
 import { Schedule } from "./Schedule";
 import { Session } from "./Session";
+import { Series } from "./Series";
 
 @ObjectType()
 export class Conference {
   @Field((_) => ID)
   public id!: string;
 
-  @Field((_) => String)
+  @Field((_) => Series)
   public series!: string;
 
   @Field((_) => String)

--- a/server/schema/resolvers/ContactResolver.ts
+++ b/server/schema/resolvers/ContactResolver.ts
@@ -12,6 +12,7 @@ import * as people from "../../../content/people";
 import * as sponsors from "../../../content/sponsors";
 import { getConference } from "../Conference";
 import { Contact, ContactType, getSessionSpeakers } from "../Contact";
+import { Location } from "../Location";
 import { IContext } from "../Context";
 import { Country } from "../Country";
 import { Image } from "../Image";
@@ -59,7 +60,7 @@ class ContactResolver {
     return contact;
   }
 
-  @Query((_) => [Contact])
+  @Query((_) => [Location])
   public locations() {
     return Object.values(locations);
   }


### PR DESCRIPTION
As an experiment of [AutoGraphQL](https://github.com/ASSERT-KTH/autographql/tree/master/tool/autographql) tool, I used the project to test its schema definitions with this tool, in search of any schema fault.
With a coverage of 78%, I found two faults and asynchronicity between the resolvers and schemas:

- `series` field of `Conference` is a string but it will be resolved as a `Series` in the `conference` and `conferences` queries which results in a GraphQL type error
- return type of the `locations` query is defined to be `Contact`. Although there are some similarities between `Contact` and `Location`, if you select `locations.location`, you will get a non-nullable error as `location` is non-nullable in `Contact` but `Location` and its contents does not have this key. you also get null for `Contact` keys in `locations` query